### PR TITLE
Fix/integracao planilhas

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -37,7 +37,8 @@ function GenericTable<T extends GenericData>({
   addButton = false,
   collapsible = false,
   defaultCollapsed = true,
-  headerCollor
+  headerCollor,
+  renderCell
 }: GenericTableProps<T>) {
   const [order, setOrder] = useState<Order>("asc");
   const [orderBy, setOrderBy] = useState<keyof T>(defaultOrderBy);
@@ -224,7 +225,9 @@ function GenericTable<T extends GenericData>({
                           maxWidth: "10rem",
                         }}
                       >
-                        {headCell.iconAction ? (
+                        {renderCell && renderCell(headCell.id, row) !== undefined ? (
+                          renderCell(headCell.id, row)
+                        ) : headCell.iconAction ? (
                           <Box
                             onClick={(e) => {
                               e.stopPropagation();
@@ -265,6 +268,7 @@ function GenericTable<T extends GenericData>({
                       </TableCell>
                     );
                   })}
+
                 </TableRow>
               );
             })}

--- a/src/components/modal/createOperationModal.tsx
+++ b/src/components/modal/createOperationModal.tsx
@@ -57,8 +57,8 @@ const CreateOperationModal: React.FC<CreateOperationModalProps> = ({
       reset();
       onClose();
     } catch (err) {
-      console.error("Erro ao criar operação:", err);
-      setSubmitError("Não foi possível criar a operação. Tente novamente.");
+      if (err)
+        setSubmitError("Não foi possível criar a operação. Tente novamente.");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/modal/createSuspectModal.tsx
+++ b/src/components/modal/createSuspectModal.tsx
@@ -322,8 +322,7 @@ const CreateSuspectModal: React.FC<CreateSuspectModalProps> = ({ isOpen, onClose
 
         <Button
           type="submit"
-          onClick={handleSubmit((data) => {
-            console.log(data);
+          onClick={handleSubmit(() => {
             reset();
             onClose();
           })}

--- a/src/components/modal/uploadWorksheetModal.tsx
+++ b/src/components/modal/uploadWorksheetModal.tsx
@@ -32,7 +32,7 @@ type UploadModalForm = z.infer<typeof uploadModalSchema>;
 
 interface UploadModalProps {
   isOpen: boolean;
-  onUploadSuccess: (file: File) => void;
+  onUploadSuccess: (file: File, operacaoId: string) => void;
   onClose: () => void;
   existingFiles: string[];
   operationsList: Operation[];
@@ -46,7 +46,6 @@ const UploadWorksheetModal: React.FC<UploadModalProps> = ({
   operationsList
 }) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
-
 
   const {
     control,
@@ -82,10 +81,10 @@ const UploadWorksheetModal: React.FC<UploadModalProps> = ({
       });
       return false;
     }
-      clearErrors("uploadFile");
-      setValue("uploadFile", file, { shouldValidate: true });
+    clearErrors("uploadFile");
+    setValue("uploadFile", file, { shouldValidate: true });
 
-      return true;
+    return true;
   };
 
   const onSubmit = (data: UploadModalForm) => {
@@ -102,9 +101,9 @@ const UploadWorksheetModal: React.FC<UploadModalProps> = ({
     }
     setSubmitError(null);
     reset();
-    onUploadSuccess(data.uploadFile);
+    onUploadSuccess(data.uploadFile, data.operations[0]);
   }
-  
+
   return (
     <Dialog
       sx={{
@@ -173,20 +172,20 @@ const UploadWorksheetModal: React.FC<UploadModalProps> = ({
           <Typography sx={{ fontWeight: 800, fontSize: "1rem" }}>
             Operações*
           </Typography>
-          <Controller
-            control={control}
-            name="operations"
-            render={({ field }) => (
-              <MultiSelect
-                placeholder="Selecione as operações"
-                height="2.5rem"
-                options={operationsList.map((operation) => (operation.nome))}
-                selectedOptions={field.value}
-                onChange={handleChangeOperations} 
-                style={"gray"} 
-              />
-            )}
-          />
+            <Controller
+              control={control}
+              name="operations"
+              render={({ field }) => (
+                <MultiSelect
+                  style="white"
+                  placeholder="Selecione as operações"
+                  height="2.5rem"
+                  options={operationsList.map((op) => op.nome)}
+                  selectedOptions={field.value}
+                  onChange={handleChangeOperations}
+                />
+              )}
+            />
           <Box height="1.5rem">
             {errors.operations && (
               <Typography color="error" variant="caption">

--- a/src/components/modal/uploadWorksheetModal.tsx
+++ b/src/components/modal/uploadWorksheetModal.tsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import CloseIcon from "@mui/icons-material/Close";
@@ -103,6 +103,10 @@ const UploadWorksheetModal: React.FC<UploadModalProps> = ({
     reset();
     onUploadSuccess(data.uploadFile, data.operations[0]);
   }
+
+  useEffect(() => {
+    setSubmitError(null)
+  }, [isOpen]);
 
   return (
     <Dialog

--- a/src/components/uploadAreaInput.tsx
+++ b/src/components/uploadAreaInput.tsx
@@ -16,11 +16,9 @@ const UploadAreaInput: React.FC<UploadAreaInputProps> = ({
       const selectedFile = e.target.files[0];
       if (onFileSelect(selectedFile)) {        
         setFileName(selectedFile.name);
-        console.log(selectedFile);
       }
       else {
         setFileName(null);
-        console.error("Invalid file selected.");
       }
     }
   };

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -19,6 +19,8 @@ const endpoints = {
   SHEETS: {
     getAll: 'api/planilha',
     upload: 'api/interceptacao/upload',
+    getProgress: 'api/upload/progresso',
+    getPendingJobs: 'api/upload/progresso'
   },
 };
 

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -15,7 +15,11 @@ const endpoints = {
   WEB: {
     // EX: página do gráfico de teia
     createWeb: "api/teia/message"
-  }
+  },
+  SHEETS: {
+    getAll: 'api/planilha',
+    upload: 'api/interceptacao/upload',
+  },
 };
 
 export default endpoints;

--- a/src/controllers/operationController.ts
+++ b/src/controllers/operationController.ts
@@ -3,12 +3,6 @@ import { Operation } from "../hooks/useOperations";
 import { api } from "../server/service";
 
 export async function createOperation(operation: Operation): Promise<Operation> {
-    try {
-        const response = await api.post<Operation>(endpoints.OPERATION.createOperation, operation);
-        return response.data;
-    }
-    catch (error) {
-        console.error("Erro ao criar operação:", error);
-        throw error;
-    }
+    const response = await api.post<Operation>(endpoints.OPERATION.createOperation, operation);
+    return response.data;
 }

--- a/src/controllers/sheetController.ts
+++ b/src/controllers/sheetController.ts
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import endpoints from '../constants/endpoints';
+import { api } from '../server/service';
+
+export interface SheetResponse {
+  Planilhas: Array<{
+    id: number;
+    nome: string;
+    data_upload: string;
+    size: number;
+  }>;
+}
+
+export interface SheetUploadRequest {
+  file: File;
+  operacaoId: string;
+}
+
+class SheetController {
+  async getAllSheets(): Promise<SheetResponse> {
+    try {
+      const response = await api.get<SheetResponse>(endpoints.SHEETS.getAll);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching sheets:', error);
+      throw error;
+    }
+  }
+
+  async uploadSheet(request: SheetUploadRequest): Promise<{ Message: string }> {
+    try {
+      const formData = new FormData();
+      formData.append('file', request.file);
+      formData.append('operacaoId', request.operacaoId);
+
+      console.log('Request details:', {
+        file: request.file,
+        operacaoId: request.operacaoId,
+        formData: Object.fromEntries(formData.entries())
+      });
+
+      const response = await api.post<{ Message: string }>(
+        endpoints.SHEETS.upload,
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error uploading sheet:', error);
+      if (axios.isAxiosError(error)) {
+        console.error('Request details:', {
+          url: error.config?.url,
+          method: error.config?.method,
+          headers: error.config?.headers,
+          data: error.config?.data
+        });
+        console.error('Response data:', error.response?.data);
+      }
+      throw error;
+    }
+  }
+}
+
+export const sheetController = new SheetController();

--- a/src/controllers/sheetController.ts
+++ b/src/controllers/sheetController.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import endpoints from '../constants/endpoints';
 import { api } from '../server/service';
 
@@ -11,6 +10,13 @@ export interface SheetResponse {
   }>;
 }
 
+export interface PendingJob {
+  job_id: string;
+  nome: string;
+  size: number;
+  data_upload?: string;
+}
+
 export interface SheetUploadRequest {
   file: File;
   operacaoId: string;
@@ -18,51 +24,46 @@ export interface SheetUploadRequest {
 
 class SheetController {
   async getAllSheets(): Promise<SheetResponse> {
+    const response = await api.get<SheetResponse>(endpoints.SHEETS.getAll);
+    return response.data;
+  }
+
+  async getPendingJobs(): Promise<PendingJob[]> {
     try {
-      const response = await api.get<SheetResponse>(endpoints.SHEETS.getAll);
+      const response = await api.get<PendingJob[]>(endpoints.SHEETS.getPendingJobs);
       return response.data;
     } catch (error) {
-      console.error('Error fetching sheets:', error);
-      throw error;
+      console.error("Erro ao buscar jobs pendentes:", error);
+      return [];
     }
   }
 
-  async uploadSheet(request: SheetUploadRequest): Promise<{ Message: string }> {
-    try {
-      const formData = new FormData();
-      formData.append('file', request.file);
-      formData.append('operacaoId', request.operacaoId);
+  async uploadSheet(request: SheetUploadRequest): Promise<{ job_id: string }> {
+    const formData = new FormData();
+    formData.append('file', request.file);
+    formData.append('operacaoId', request.operacaoId);
 
-      console.log('Request details:', {
-        file: request.file,
-        operacaoId: request.operacaoId,
-        formData: Object.fromEntries(formData.entries())
-      });
-
-      const response = await api.post<{ Message: string }>(
-        endpoints.SHEETS.upload,
-        formData,
-        {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
-        }
-      );
-      return response.data;
-    } catch (error) {
-      console.error('Error uploading sheet:', error);
-      if (axios.isAxiosError(error)) {
-        console.error('Request details:', {
-          url: error.config?.url,
-          method: error.config?.method,
-          headers: error.config?.headers,
-          data: error.config?.data
-        });
-        console.error('Response data:', error.response?.data);
+    const response = await api.post<{ job_id: string }>(
+      endpoints.SHEETS.upload,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
       }
-      throw error;
-    }
+    );
+    return response.data;
   }
-}
+  async getUploadProgress(jobId: string): Promise<{
+    status: string;
+    progress: number;
+    erro: boolean;
+    mensagem: string | null;
+  }> {
+    const response = await api.get(endpoints.SHEETS.getProgress + `/${jobId}`);
+    return response.data;
+  }
 
+
+}
 export const sheetController = new SheetController();

--- a/src/hooks/useSuspects.ts
+++ b/src/hooks/useSuspects.ts
@@ -58,8 +58,6 @@ export const useSuspects = ({ searchTerm, operationIds }: UseSuspectsProps) => {
     setError(null);
 
     const url = `/api/numeros/operacao/${operationIds.join(",")}`;
-    console.log("fetching:", url);
-
     api
       .get<SuspectList>(url)
       .then(({ data }) => setData(data))

--- a/src/hooks/useWorksheets.ts
+++ b/src/hooks/useWorksheets.ts
@@ -1,50 +1,50 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { normalizeString } from "../utils/formatUtils";
 import { GenericData } from "../interface/operationSuspectTable/operationSuspectTableInterface";
+import { sheetController } from "../controllers/sheetController";
 
 export interface WorkSheet extends GenericData {
   id: number;
-  worksheet: string;
-  size: string;
-  insertedBy: string;
-  date: string;
-  
+  nome: string;
+  size: number;
+  data_upload: string;
+  [key: string]: string | number | string[];
 }
+
 interface UseOperationsProps {
   searchTerm: string;
 }
 
-export const mockWorksheets: WorkSheet[] = [
-  {
-    id: 1,
-    worksheet: "Planilha 1",
-    size: "14MB",
-    insertedBy: "012.345.678-90",
-    operationName: "Operação A",
-    date: "01-10-2023",
-  },
-  {
-    id: 2,
-    worksheet: "Planilha 2",
-    size: "2MB",
-    insertedBy: "234.234.234-23",
-    operationName: "Operação B, Operação C",
-    date: "12-09-2023",
-  },
-  {
-    id: 3,
-    worksheet: "Planilha 3",
-    size: "1MB",
-    insertedBy: "345.345.345-34",
-    operationName: "Operação A, Operação C, Operação D, Operação E, Operação F, Operação G, Operação H",
-    date: "12-05-2024",
-  },
-];
-
 export const useWorksheets = ({ searchTerm }: UseOperationsProps) => {
+  const [worksheets, setWorksheets] = useState<WorkSheet[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
 
-  const [worksheets, setWorksheets] = useState<WorkSheet[]>(mockWorksheets);
-  
+  useEffect(() => {
+    const fetchWorksheets = async () => {
+      try {
+        setIsLoading(true);
+        const response = await sheetController.getAllSheets();
+        // Transform backend data to match frontend interface
+        const transformedWorksheets = Array.isArray(response.Planilhas)
+          ? response.Planilhas.map((sheet) => ({
+              id: sheet.id,
+              nome: sheet.nome,
+              size: sheet.size,
+              data_upload: sheet.data_upload,
+            }))
+          : [];
+        setWorksheets(transformedWorksheets);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch worksheets'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchWorksheets();
+  }, []);
+
   const filteredWorksheets = useMemo(() => {
     let result = [...worksheets];
 
@@ -52,31 +52,27 @@ export const useWorksheets = ({ searchTerm }: UseOperationsProps) => {
       const normalizedSearch = normalizeString(searchTerm.trim());
       result = result.filter(
         (worksheet) =>
-          normalizeString(worksheet.worksheet).includes(normalizedSearch) ||
+          normalizeString(worksheet.nome).includes(normalizedSearch) ||
           String(worksheet.id).includes(normalizedSearch)
       );
     }
 
-    return result.sort((a, b) => a.worksheet.localeCompare(b.worksheet));
+    return result.sort((a, b) => a.nome.localeCompare(b.nome));
   }, [searchTerm, worksheets]);
 
-
-  function addWorksheet(
-    worksheet: string,
-    size: string,
-    insertedBy: string,
-    date: string
+  async function addWorksheet(
+    nome: string,
+    size: number,
+    data_upload: string
   ) {
     const newWorksheet: WorkSheet = {
-      id: mockWorksheets.length + 1,
-      worksheet,
+      id: worksheets.length + 1,
+      nome,
       size,
-      insertedBy,
-      operationName: "Operação A",
-      date,
+      data_upload,
     };
     setWorksheets((prevWorksheets) => [...prevWorksheets, newWorksheet]);
   }
 
-  return {filteredWorksheets, addWorksheet };
+  return { filteredWorksheets, addWorksheet, isLoading, error };
 };

--- a/src/hooks/useWorksheets.ts
+++ b/src/hooks/useWorksheets.ts
@@ -1,78 +1,189 @@
 import { useMemo, useState, useEffect } from "react";
 import { normalizeString } from "../utils/formatUtils";
-import { GenericData } from "../interface/operationSuspectTable/operationSuspectTableInterface";
 import { sheetController } from "../controllers/sheetController";
+import { GenericData } from "../interface/table/tableInterface";
 
 export interface WorkSheet extends GenericData {
   id: number;
   nome: string;
   size: number;
   data_upload: string;
-  [key: string]: string | number | string[];
+  status?: string;
+  progress?: number;
+  job_id?: string;
+  [key: string]: string | number | string[] | undefined;
 }
 
-interface UseOperationsProps {
+interface UseWorksheetsProps {
   searchTerm: string;
 }
 
-export const useWorksheets = ({ searchTerm }: UseOperationsProps) => {
+export const useWorksheets = ({ searchTerm }: UseWorksheetsProps) => {
   const [worksheets, setWorksheets] = useState<WorkSheet[]>([]);
+  const [pendingUploads, setPendingUploads] = useState<WorkSheet[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
+  // Fetch planilhas persistidas
   useEffect(() => {
-    const fetchWorksheets = async () => {
-      try {
-        setIsLoading(true);
-        const response = await sheetController.getAllSheets();
-        // Transform backend data to match frontend interface
-        const transformedWorksheets = Array.isArray(response.Planilhas)
-          ? response.Planilhas.map((sheet) => ({
-              id: sheet.id,
-              nome: sheet.nome,
-              size: sheet.size,
-              data_upload: sheet.data_upload,
-            }))
-          : [];
-        setWorksheets(transformedWorksheets);
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error('Failed to fetch worksheets'));
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchWorksheets();
+    fetchSheetsAgain();
+    fetchPendingJobs();
   }, []);
 
+  // Agrupa todas as planilhas (persistidas + pendentes)
   const filteredWorksheets = useMemo(() => {
-    let result = [...worksheets];
+    let combined = [...pendingUploads, ...worksheets];
 
     if (searchTerm?.trim()) {
       const normalizedSearch = normalizeString(searchTerm.trim());
-      result = result.filter(
-        (worksheet) =>
-          normalizeString(worksheet.nome).includes(normalizedSearch) ||
-          String(worksheet.id).includes(normalizedSearch)
+      combined = combined.filter(
+        (w) =>
+          normalizeString(w.nome).includes(normalizedSearch) ||
+          String(w.id).includes(normalizedSearch)
       );
     }
 
-    return result.sort((a, b) => a.nome.localeCompare(b.nome));
-  }, [searchTerm, worksheets]);
+    return combined.sort((a, b) => a.nome.localeCompare(b.nome));
+  }, [searchTerm, worksheets, pendingUploads]);
 
-  async function addWorksheet(
-    nome: string,
-    size: number,
-    data_upload: string
-  ) {
-    const newWorksheet: WorkSheet = {
-      id: worksheets.length + 1,
+  function addPendingUpload(nome: string, size: number, job_id?: string) {
+    const id = Date.now();
+
+    const newSheet: WorkSheet = {
+      id: id,
       nome,
       size,
-      data_upload,
+      data_upload: new Date().toISOString().slice(0, 10),
+      job_id,
+      status: job_id ? "Recebendo arquivo" : "Aguardando job_id",
+      progress: 0,
     };
-    setWorksheets((prevWorksheets) => [...prevWorksheets, newWorksheet]);
+
+    setPendingUploads((prev) => prev.filter(sheet => sheet.nome !== nome))
+    setPendingUploads((prev) => [...prev, newSheet]);
+
+    if (job_id) {
+      pollUploadProgress(job_id);
+    }
   }
 
-  return { filteredWorksheets, addWorksheet, isLoading, error };
+  function removePendingUpload(name: string) {
+    setPendingUploads((prev) =>
+      prev.map((p) =>
+        p.nome === name ? { ...p, status: "Erro ao iniciar upload", progress: 0 } : p
+      )
+    );
+  }
+  function associateJobId(nome: string, job_id: string) {
+    setPendingUploads((prev) =>
+      prev.map((p) =>
+        p.nome === nome && !p.job_id ? { ...p, job_id, status: "Recebendo arquivo" } : p
+      )
+    );
+
+    pollUploadProgress(job_id);
+  }
+
+  function updatePendingProgress(job_id: string, status: string, progress: number) {
+    setPendingUploads((prev) =>
+      prev.map((p) =>
+        p.job_id === job_id ? { ...p, status, progress } : p
+      )
+    );
+  }
+
+  function pollUploadProgress(job_id: string) {
+    let errorCount = 0;
+    const MAX_ERRORS = 5;
+
+    const interval = setInterval(async () => {
+      try {
+        const progress = await sheetController.getUploadProgress(job_id);
+        updatePendingProgress(job_id, progress.status, progress.progress);
+        errorCount = 0; // reset erro se sucesso
+
+        if (progress.erro) {
+          clearInterval(interval);
+          return;
+        }
+
+        if (progress.status === "Concluído") {
+          clearInterval(interval);
+          setPendingUploads((prev) => prev.filter((p) => p.job_id !== job_id));
+          fetchSheetsAgain();
+        }
+      } catch (error) {
+        console.error("Erro ao consultar progresso do job:", error);
+        errorCount += 1;
+
+        if (errorCount >= MAX_ERRORS) {
+          updatePendingProgress(job_id, "Erro de conexão com backend", 0);
+          clearInterval(interval);
+        }
+      }
+    }, 1000);
+  }
+
+  async function fetchSheetsAgain() {
+    try {
+      setIsLoading(true); // Adicionado
+      const response = await sheetController.getAllSheets();
+      const transformed = Array.isArray(response.Planilhas)
+        ? response.Planilhas.map((sheet) => ({
+          id: sheet.id,
+          nome: sheet.nome,
+          size: sheet.size,
+          data_upload: sheet.data_upload,
+          status: "Concluído",
+        }))
+        : [];
+      setWorksheets(transformed);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Failed to refresh worksheets"));
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function fetchPendingJobs() {
+    try {
+      const jobs = await sheetController.getPendingJobs();
+
+      if (!Array.isArray(jobs)) return;
+
+      setPendingUploads((prev) => {
+        const existingJobIds = new Set(prev.map((p) => p.job_id));
+        const newUploads: WorkSheet[] = [];
+
+        for (const job of jobs) {
+          if (!existingJobIds.has(job.job_id)) {
+            newUploads.push({
+              id: Date.now() + Math.random(),
+              nome: job.nome,
+              size: job.size,
+              data_upload: job.data_upload ?? new Date().toISOString().slice(0, 10),
+              job_id: job.job_id,
+              status: "Recebendo arquivo",
+              progress: 0,
+            });
+
+            pollUploadProgress(job.job_id);
+          }
+        }
+
+        return [...prev, ...newUploads];
+      });
+    } catch (err) {
+      console.error("Erro ao buscar jobs pendentes:", err);
+    }
+  }
+
+  return {
+    filteredWorksheets,
+    isLoading,
+    error,
+    addPendingUpload,
+    associateJobId,
+    removePendingUpload
+  };
 };

--- a/src/interface/operationSuspectTable/operationSuspectTableInterface.ts
+++ b/src/interface/operationSuspectTable/operationSuspectTableInterface.ts
@@ -1,6 +1,6 @@
 export interface GenericData {
   id: number;
-  [key: string]: string | number | string[];
+  [key: string]: string | number | string[] | number[] | undefined;
 }
 
 export interface HeadCell<T extends GenericData> {

--- a/src/interface/table/tableInterface.ts
+++ b/src/interface/table/tableInterface.ts
@@ -5,7 +5,7 @@ export interface IconAction {
 
 export interface GenericData {
   id: number;
-  [key: string]: string | number | string[];
+  [key: string]: string | number | string[] | number[] | undefined;
 }
 
 export interface HeadCell<T extends GenericData> {
@@ -36,6 +36,7 @@ export interface GenericTableProps<T extends GenericData> {
   headerCollor?: string;
   collapsible?: boolean;
   defaultCollapsed?: boolean;
+  renderCell?: (id: keyof T, row: T) => React.ReactNode;
 }
 
 export interface EnhancedTableHeadProps<T extends GenericData> {

--- a/src/routes/Worksheet/index.tsx
+++ b/src/routes/Worksheet/index.tsx
@@ -1,52 +1,78 @@
-import { Box, Button, Typography } from "@mui/material";
-import React, { useCallback, useState } from "react";
-// import { useNavigate, useSearchParams } from "react-router-dom";
+import { Box, Button, Typography, CircularProgress, Alert } from "@mui/material";
+import React, { useCallback, useContext, useState } from "react";
 import { HeadCell } from "../../interface/table/tableInterface";
 import GenericTable from "../../components/Table/Table";
 import { useWorksheets, WorkSheet } from "../../hooks/useWorksheets";
 import { useHeaderInput } from "../../hooks/useHeaderInput";
 import UploadWorksheetModal from "../../components/modal/uploadWorksheetModal";
+import { sheetController } from "../../controllers/sheetController";
 import { useOperations } from "../../hooks/useOperations";
+import { AppContext } from "../../context/AppContext";
+
+const workSheetsHeaderCells: readonly HeadCell<WorkSheet>[] = [
+  {
+    id: "nome",
+    label: "Planilha",
+  },
+  {
+    id: "size",
+    label: "Tamanho do arquivo",
+  },
+  {
+    id: "data_upload",
+    label: "Data de Upload",
+  },
+];
 
 const Worksheet: React.FC = () => {
-  const [_, setSelectedWorksheets] = useState<WorkSheet[]>([]);
+  const { setWorksheets } = useContext(AppContext);
   const [selectedIds, setSelectedIds] = useState<readonly number[]>([]);
-
-  const workSheetsHeaderCells: readonly HeadCell<WorkSheet>[] = [
-    {
-      id: "worksheet",
-      label: "Planilhas",
-    },
-    {
-      id: "size",
-      label: "Tamanho do arquivo",
-    },
-    {
-      id: "insertedBy",
-      label: "Adicionado por",
-    },
-    {
-      id: "operationName",
-      label: "Operações",
-    },
-    {
-      id: "date",
-      label: "Data de Inserção",
-    },
-  ];
-
-  const handleSelectionChange = useCallback((selectedIds: readonly number[], selectedItems: WorkSheet[]) => {
-      setSelectedIds(selectedIds);
-      setSelectedWorksheets(selectedItems);
-    },
-    [setSelectedWorksheets]
-  );
-
   const [openModal, setOpenModal] = useState<boolean>(false);
   const { headerInputValue } = useHeaderInput();
-  const { filteredWorksheets, addWorksheet } = useWorksheets({ searchTerm: headerInputValue });
   const { filteredOperations } = useOperations({ searchTerm: "" });
 
+  const { filteredWorksheets, addWorksheet, isLoading, error } = useWorksheets({
+    searchTerm: headerInputValue,
+  });
+  
+  const handleSelectionChange = useCallback(
+    (selectedIds: readonly number[], selectedItems: WorkSheet[]) => {
+      setSelectedIds(selectedIds);
+      setWorksheets(selectedItems);
+    },
+    [setWorksheets]
+  );
+
+  const handleUpload = async (file: File, operation: string) => {
+    try {
+      const response = await sheetController.uploadSheet({ 
+        file, 
+        operacaoId: operation 
+      });
+      console.log("response", response);
+      if (response.Message === "success") {
+        setOpenModal(false);
+        // Refresh the worksheets list
+        addWorksheet(
+          file.name,
+          file.size,
+          new Date().toISOString()
+        );
+      }
+    } catch (error) {
+      console.error("Error uploading sheet:", error);
+    }
+  };
+
+  if (error) {
+    return (
+      <Box p={3}>
+        <Alert severity="error">
+          Erro ao carregar as planilhas: {error.message}
+        </Alert>
+      </Box>
+    );
+  }
 
   return (
     <Box p={3} sx={{ fontFamily: "Inter, sans-serif" }}>
@@ -79,42 +105,33 @@ const Worksheet: React.FC = () => {
         </Button>
       </Box>
 
-      <GenericTable
-        singleSelect={true}
-        rows={filteredWorksheets}
-        headCells={workSheetsHeaderCells}
-        title="Planilhas"
-        defaultOrderBy="suspectName"
-        onSelectionChange={handleSelectionChange}
-        initialSelected={selectedIds}
-        noDataMessage="Nenhuma planilha encontrada"
-        onDelete={() => { }}
-      />
+      {isLoading ? (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+          <CircularProgress />
+        </Box>
+      ) : (
+        <GenericTable
+          singleSelect={true}
+          rows={filteredWorksheets}
+          headCells={workSheetsHeaderCells}
+          title="Planilhas"
+          defaultOrderBy="nome"
+          onSelectionChange={handleSelectionChange}
+          initialSelected={selectedIds}
+          noDataMessage="Nenhuma planilha encontrada"
+          onDelete={() => {}}
+        />
+      )}
       <Box sx={{ width: "100%", display: "flex", justifyContent: "end" }}>
       </Box>
       <UploadWorksheetModal
         isOpen={openModal}
-        operationsList={filteredOperations}
         onClose={() => setOpenModal(false)}
-        data-testid="close-modal-button"
-        onUploadSuccess={(file) => {
-          setOpenModal(false);
-
-          const cpf = localStorage.getItem("cpf") || "000.000.000-00";
-          addWorksheet(
-            file.name,
-            file.size.toString(),
-            cpf,
-            new Date().toLocaleDateString("pt-BR", {
-              year: "numeric",
-              month: "2-digit",
-              day: "2-digit",
-            })
-          );
-        }}
+        onUploadSuccess={handleUpload}
         existingFiles={filteredWorksheets.map(
-          (worksheet) => worksheet.worksheet
+          (worksheet) => worksheet.nome
         )}
+        operationsList={filteredOperations}
       />
     </Box>
   );

--- a/src/routes/Worksheet/index.tsx
+++ b/src/routes/Worksheet/index.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Typography, CircularProgress, Alert } from "@mui/material";
+import {
+  Box,
+  Button,
+  Typography,
+  CircularProgress,
+  Alert,
+  Tooltip,
+  LinearProgress,
+} from "@mui/material";
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import React, { useCallback, useContext, useState } from "react";
 import { HeadCell } from "../../interface/table/tableInterface";
 import GenericTable from "../../components/Table/Table";
@@ -10,18 +19,10 @@ import { useOperations } from "../../hooks/useOperations";
 import { AppContext } from "../../context/AppContext";
 
 const workSheetsHeaderCells: readonly HeadCell<WorkSheet>[] = [
-  {
-    id: "nome",
-    label: "Planilha",
-  },
-  {
-    id: "size",
-    label: "Tamanho do arquivo",
-  },
-  {
-    id: "data_upload",
-    label: "Data de Upload",
-  },
+  { id: "nome", label: "Planilha" },
+  { id: "size", label: "Tamanho do arquivo" },
+  { id: "data_upload", label: "Data de Upload" },
+  { id: "status", label: "Status" },
 ];
 
 const Worksheet: React.FC = () => {
@@ -31,10 +32,17 @@ const Worksheet: React.FC = () => {
   const { headerInputValue } = useHeaderInput();
   const { filteredOperations } = useOperations({ searchTerm: "" });
 
-  const { filteredWorksheets, addWorksheet, isLoading, error } = useWorksheets({
+  const {
+    filteredWorksheets,
+    addPendingUpload,
+    associateJobId,
+    removePendingUpload,
+    isLoading,
+    error,
+  } = useWorksheets({
     searchTerm: headerInputValue,
   });
-  
+
   const handleSelectionChange = useCallback(
     (selectedIds: readonly number[], selectedItems: WorkSheet[]) => {
       setSelectedIds(selectedIds);
@@ -44,31 +52,44 @@ const Worksheet: React.FC = () => {
   );
 
   const handleUpload = async (file: File, operation: string) => {
+    setOpenModal(false);
+
+    addPendingUpload(file.name, file.size);
     try {
-      const response = await sheetController.uploadSheet({ 
-        file, 
-        operacaoId: operation 
+      const response = await sheetController.uploadSheet({
+        file,
+        operacaoId: operation,
       });
-      console.log("response", response);
-      if (response.Message === "success") {
-        setOpenModal(false);
-        // Refresh the worksheets list
-        addWorksheet(
-          file.name,
-          file.size,
-          new Date().toISOString()
-        );
+
+      if (response?.job_id) {
+        associateJobId(file.name, response.job_id);
+      } else {
+        removePendingUpload(file.name);
       }
     } catch (error) {
-      console.error("Error uploading sheet:", error);
+      console.error("Erro ao fazer upload:", error);
+      removePendingUpload(file.name);
     }
   };
 
   if (error) {
     return (
-      <Box p={3}>
-        <Alert severity="error">
-          Erro ao carregar as planilhas: {error.message}
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="300px"
+      >
+        <Alert severity="error" sx={{ width: "100%", maxWidth: 600 }}>
+          <Typography fontWeight={600}>
+            Ocorreu um problema ao carregar as planilhas.
+          </Typography>
+          <Typography variant="body2">
+            {error.message === "Network Error"
+              ? "Não foi possível se conectar ao servidor. Verifique sua conexão."
+              : error.message}
+          </Typography>
         </Alert>
       </Box>
     );
@@ -76,6 +97,7 @@ const Worksheet: React.FC = () => {
 
   return (
     <Box p={3} sx={{ fontFamily: "Inter, sans-serif" }}>
+
       <Box
         display={"flex"}
         justifyContent={"space-between"}
@@ -106,10 +128,16 @@ const Worksheet: React.FC = () => {
       </Box>
 
       {isLoading ? (
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          minHeight="200px"
+        >
           <CircularProgress />
         </Box>
       ) : (
+
         <GenericTable
           singleSelect={true}
           rows={filteredWorksheets}
@@ -119,18 +147,56 @@ const Worksheet: React.FC = () => {
           onSelectionChange={handleSelectionChange}
           initialSelected={selectedIds}
           noDataMessage="Nenhuma planilha encontrada"
-          onDelete={() => {}}
+          renderCell={(columnId, row) => {
+            if (columnId === "status") {
+              const isError = String(row.status || "").toLowerCase().startsWith("erro");
+
+              if (isError) {
+                return (
+                  <Box display="flex" alignItems="center" justifyContent="center">
+                    <Tooltip title={String(row.status)} arrow>
+                      <Box display="flex" alignItems="center" gap={0.5} color="error.main">
+                        <ErrorOutlineIcon fontSize="small" />
+                        <Typography color="error">Erro</Typography>
+                      </Box>
+                    </Tooltip>
+                  </Box>
+                );
+              }
+
+              if (typeof row.progress === "number") {
+                return (
+                  <Box>
+                    <Typography variant="caption" textAlign="center" display="block">
+                      {`${row.progress}%`}
+                    </Typography>
+                    <LinearProgress
+                      variant="determinate"
+                      value={row.progress}
+                      sx={{
+                        height: 6,
+                        width: "100%",
+                        borderRadius: 4,
+                        mb: 0.5,
+                      }}
+                    />
+                  </Box>
+                );
+              }
+
+              return <Typography fontWeight={400}>Salva</Typography>;
+            }
+
+            return undefined;
+          }}
         />
       )}
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "end" }}>
-      </Box>
+
       <UploadWorksheetModal
         isOpen={openModal}
         onClose={() => setOpenModal(false)}
         onUploadSuccess={handleUpload}
-        existingFiles={filteredWorksheets.map(
-          (worksheet) => worksheet.nome
-        )}
+        existingFiles={filteredWorksheets.filter((Worksheet) => !String(Worksheet.status || "").toLowerCase().startsWith("erro")).map((worksheet) => worksheet.nome)}
         operationsList={filteredOperations}
       />
     </Box>


### PR DESCRIPTION
Adiciona integração da tela de planilhas com o backend, substituindo os dados mockados por requisições reais. Agora as planilhas são carregadas diretamente da API /api/planilha.

Implementa controle completo de uploads pendentes. Arquivos enviados mas ainda não processados são exibidos com barra de progresso, status textual e ícones de erro quando necessário. O progresso é consultado periodicamente via polling no endpoint /api/upload/progresso.

Refatora o modal de upload para permitir seleção de operações e retorno do operacaoId junto com o arquivo. O modal também exibe mensagens de erro e limpa o estado corretamente ao ser reaberto.

A tabela de planilhas (GenericTable) passa a suportar renderização personalizada por célula com a prop renderCell. Isso permite exibir barras de progresso, status e ícones dentro da tabela de forma contextual.

Além disso, remove-se o uso de dados estáticos, console.logs desnecessários e corrige-se mensagens genéricas de erro no modal de criação de operação.

