### PR TITLE
Fix/feat filtros dashboard gráficos e teia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/x-charts": "^8.0.0",
         "axios": "^1.8.2",
         "d3": "^7.9.0",
+        "dashboard-operacional-frontend": "file:",
         "date-fns": "^4.1.0",
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
@@ -4824,6 +4825,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dashboard-operacional-frontend": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mui/x-charts": "^8.0.0",
     "axios": "^1.8.2",
     "d3": "^7.9.0",
+    "dashboard-operacional-frontend": "file:",
     "date-fns": "^4.1.0",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",

--- a/src/components/dashboard/WebChart/WebChart.tsx
+++ b/src/components/dashboard/WebChart/WebChart.tsx
@@ -42,18 +42,37 @@ const Chart: React.FC<WebChartInterface> = ({ data }) => {
     const width = svgContainer ? svgContainer.clientWidth : 928;
     const height = svgContainer ? svgContainer.clientHeight : 600;
 
-    const color = d3
-      .scaleOrdinal<number, string>()
-      .domain([1, 2, 3, 4, 5, 6, 7])
-      .range([
-        "#FFB74D", // 6h-12h
-        "#4A90E2", // 12h-18h
-        "#1A237E", // 18h-00h
-        "#0D0221", // 00h-6h
-        "#D62727", // Targets
-        "#757575", // Intercepts
-        "#FFA000", // Suspects
-      ]);
+    // Mapeamento explícito de cor por grupo
+    const groupColorMap: Record<number, string> = {
+      1: "#808CBF", // Manhã
+      2: "#31438C", // Tarde
+      3: "#0F1E55", // Noite
+      4: "#D62727", // Alvos
+      5: "#000A2F", // Madrugada
+    };
+
+    const svg = d3
+      .select(svgRef.current)
+      .attr("width", width)
+      .attr("height", height)
+      .attr("viewBox", [0, 0, width, height])
+      .attr("style", "width: 100%; height: 100%; background-color: #1c1c1c")
+      .attr("data-testid", "chart-svg");
+
+    // Adicionar zoom
+    const g = svg.append("g");
+    svg.call(
+      d3
+        .zoom<SVGSVGElement, unknown>()
+        .extent([
+          [0, 0],
+          [width, height],
+        ])
+        .scaleExtent([0.1, 4])
+        .on("zoom", (event) => {
+          g.attr("transform", event.transform);
+        })
+    );
 
     const links = data.links.map((d) => ({ ...d }));
     const nodes = data.nodes.map((d) => ({ ...d }));
@@ -80,32 +99,9 @@ const Chart: React.FC<WebChartInterface> = ({ data }) => {
       )
       .force("charge", d3.forceManyBody().strength(-2000))
       .force("center", d3.forceCenter(width / 2, height / 2))
-      .force("x", d3.forceX(width / 2).strength(0.1)) // Força para manter nodos no centro X
-      .force("y", d3.forceY(height / 2).strength(0.1)) // Força para manter nodos no centro Y
+      .force("x", d3.forceX(width / 2).strength(0.1))
+      .force("y", d3.forceY(height / 2).strength(0.1))
       .force("collision", d3.forceCollide().radius(30));
-
-    const svg = d3
-      .select(svgRef.current)
-      .attr("width", width)
-      .attr("height", height)
-      .attr("viewBox", [0, 0, width, height])
-      .attr("style", "width: 100%; height: 100%; background-color: #1c1c1c")
-      .attr("data-testid", "chart-svg");
-
-    // Adicionar zoom
-    const g = svg.append("g");
-    svg.call(
-      d3
-        .zoom<SVGSVGElement, unknown>()
-        .extent([
-          [0, 0],
-          [width, height],
-        ])
-        .scaleExtent([0.1, 4])
-        .on("zoom", (event) => {
-          g.attr("transform", event.transform);
-        })
-    );
 
     const link = g
       .append("g")
@@ -128,7 +124,7 @@ const Chart: React.FC<WebChartInterface> = ({ data }) => {
       .data(nodes)
       .join("circle")
       .attr("r", 15)
-      .attr("fill", (d) => color(d.group))
+      .attr("fill", (d) => groupColorMap[d.group] || "#757575")
       .style("cursor", "pointer")
       .on("dblclick", (_event, d) => {
         window.open(`/node/${d.id}`, "_blank");
@@ -143,7 +139,7 @@ const Chart: React.FC<WebChartInterface> = ({ data }) => {
       .attr("fill", "#fff")
       .attr("text-anchor", "middle")
       .attr("dy", "-2em")
-      .attr("font-size", "14px"); // Aumentando o tamanho da fonte
+      .attr("font-size", "14px");
 
     node.call(
       d3
@@ -160,9 +156,9 @@ const Chart: React.FC<WebChartInterface> = ({ data }) => {
         .attr("x2", (d) => (d.target as Node).x || 0)
         .attr("y2", (d) => (d.target as Node).y || 0);
 
-      node.attr("cx", (d) => d.x || 0).attr("cy", (d) => d.y || 0); // Node position
+      node.attr("cx", (d) => d.x || 0).attr("cy", (d) => d.y || 0);
 
-      nodeText.attr("x", (d) => d.x || 0).attr("y", (d) => d.y || 0); // Node text
+      nodeText.attr("x", (d) => d.x || 0).attr("y", (d) => d.y || 0);
     }
 
     function dragstarted(event: d3.D3DragEvent<SVGCircleElement, Node, Node>) {

--- a/src/components/editableField.tsx
+++ b/src/components/editableField.tsx
@@ -44,20 +44,24 @@ const EditableField = ({
           InputProps={{ readOnly: !editing }}
           sx={{
             width: "100%",
-            "& .MuiOutlinedInput-root": {
-              borderRadius: editing ? "0.313rem" : "0.313rem 0 0 0.313rem",
-              backgroundColor: "white",
-              "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-                borderColor: "customButton.gold",
+            '& .MuiOutlinedInput-root': {
+              borderRadius: editing ? '0.313rem' : '0.313rem 0 0 0.313rem',
+              backgroundColor: 'white',
+              '&:hover .MuiOutlinedInput-notchedOutline': {
+                borderColor: 'customButton.lightGray',
+              },
+              '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                borderColor: 'customButton.lightGray',
+                borderWidth: '1px',
               },
             },
-            "& .MuiOutlinedInput-input": {
-              padding: "0.625rem",
-              fontFamily: "Inter, sans-serif",
+            '& .MuiOutlinedInput-input': {
+              padding: '0.625rem',
+              fontFamily: 'Inter, sans-serif',
               fontWeight: 400,
             },
-            "& label.Mui-focused": {
-              color: "customButton.gold",
+            '& label.Mui-focused': {
+              color: 'inherit',
             },
           }}
         />

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -52,10 +52,10 @@ export const ApplicationProvider = ({
   });
 
   const [webChartFilters, setWebChartFilters] = useState<ChartFilters>({
-    type: "Texto",
-    group: "Ambos",
+    type: "Todos",
+    group: "Todos",
     options: [] as string[],
-    symmetry: "Ambos",
+    symmetry: "Todos",
   });
 
   return (

--- a/src/interface/web/webInterface.ts
+++ b/src/interface/web/webInterface.ts
@@ -7,6 +7,7 @@ export interface WebLink {
     source: string;
     target: string;
     value: number;
+    date?: string;
 }
 
 export interface CreateWeb {

--- a/src/routes/NetworkWeb/index.tsx
+++ b/src/routes/NetworkWeb/index.tsx
@@ -1,8 +1,10 @@
-import { Box, MenuItem, TextField, Typography } from "@mui/material";
+import { Box, MenuItem, TextField, Typography, Collapse, IconButton } from "@mui/material";
 import React, { useState, useMemo } from "react";
 import WebChart from "../../components/dashboard/WebChart/WebChart";
 import MultiSelect from "../../components/multiSelect";
 import dayjs from "dayjs";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 
 const menuItemStyles = {
   padding: "4px 16px",
@@ -240,12 +242,23 @@ const options = mockData.nodes
   .map((node) => node.id);
 
 const NetworkWebRoute: React.FC = () => {
+  const [expanded, setExpanded] = useState(true);
   const [selectedType, setSelectedType] = useState("IP");
   const [selectedGroup, setSelectedGroup] = useState("Ambos");
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
-  const [selectedSimmetry, setSelectedSimmetry] = useState("Ambos");
-  const [dateInitial, setDateInitial] = useState("");
+  const [selectedShift, setSelectedShift] = useState("Todos");
+  
+  // Definir data inicial como 1 mês atrás
+  const oneMonthAgo = new Date();
+  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+  const [dateInitial, setDateInitial] = useState(oneMonthAgo.toISOString().split('T')[0]);
   const [dateFinal, setDateFinal] = useState("");
+  const [timeInitial, setTimeInitial] = useState("00:00");
+  const [timeFinal, setTimeFinal] = useState("23:59");
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
 
   // Filtragem dos nós e links
   const filteredData = useMemo(() => {
@@ -308,16 +321,18 @@ const NetworkWebRoute: React.FC = () => {
       );
     }
 
-    // Filtro de Simetria
-    if (selectedSimmetry !== "Ambos") {
+    // Filtro de Turno
+    if (selectedShift !== "Todos") {
       links = links.filter((link) => {
         const sourceNode = nodes.find((n) => n.id === link.source);
         const targetNode = nodes.find((n) => n.id === link.target);
         if (!sourceNode || !targetNode) return false;
-        if (selectedSimmetry === "Simétricos") {
-          return sourceNode.group === targetNode.group;
-        } else if (selectedSimmetry === "Assimétricos") {
-          return sourceNode.group !== targetNode.group;
+        if (selectedShift === "Manhã") {
+          return sourceNode.group === 1 && targetNode.group === 1;
+        } else if (selectedShift === "Tarde") {
+          return sourceNode.group === 2 && targetNode.group === 2;
+        } else if (selectedShift === "Noite") {
+          return sourceNode.group === 3 && targetNode.group === 3;
         }
         return true;
       });
@@ -331,7 +346,7 @@ const NetworkWebRoute: React.FC = () => {
     selectedOptions,
     selectedGroup,
     selectedType,
-    selectedSimmetry,
+    selectedShift,
     dateInitial,
     dateFinal,
   ]);
@@ -348,202 +363,281 @@ const NetworkWebRoute: React.FC = () => {
       <Box
         display="flex"
         flexDirection="column"
-        gap="0.5rem"
-        px="1.5rem"
-        py="0.5rem"
-        style={{ minHeight: 0 }}
+        justifyContent="space-between"
+        borderBottom={expanded ? "1px solid #e0e0e0" : "none"}
+        sx={{
+          transition: "all 0.3s ease-in-out",
+        }}
       >
-        <Box
+        <Collapse in={expanded} timeout="auto">
+          <Box 
+            display="flex" 
+            flexDirection="column" 
+            gap="1.5rem" 
+            px="1.5rem"
+            py="1rem"
+            sx={{
+              transition: "all 0.3s ease-in-out",
+            }}
+          >
+            <Box
+              sx={{
+                width: "fit-content",
+                minWidth: "25rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.75rem",
+              }}
+            >
+              <Typography
+                fontFamily={"Inter, sans-serif"}
+                fontWeight={600}
+                fontSize={"1.25rem"}
+                color="text.primary"
+              >
+                Seleção de IPs
+              </Typography>
+              <MultiSelect
+                style="gray"
+                placeholder="Selecione os IPs"
+                height="53px"
+                options={options}
+                selectedOptions={selectedOptions}
+                onChange={setSelectedOptions}
+              />
+            </Box>
+
+            <Box width="100%" display="flex" flexDirection="column" gap="0.75rem">
+              <Typography
+                variant="caption"
+                fontSize={"14px"}
+                fontFamily="Inter, sans-serif"
+                fontWeight={600}
+                color="text.primary"
+              >
+                Filtrar por:
+              </Typography>
+
+              <Box 
+                display="flex" 
+                flexDirection="row" 
+                flexWrap="wrap" 
+                gap="2.5rem"
+                sx={{
+                  transition: "all 0.3s ease-in-out",
+                }}
+              >
+                <TextField
+                  select
+                  label="Grupo"
+                  value={selectedGroup}
+                  onChange={(e) => setSelectedGroup(e.target.value)}
+                  sx={{ ...focusedTextFieldStyles, backgroundColor: "transparent" }}
+                >
+                  {["IP", "Interlocutor", "Ambos"].map((value) => (
+                    <MenuItem key={value} value={value} sx={menuItemStyles}>
+                      {value}
+                    </MenuItem>
+                  ))}
+                </TextField>
+
+                <TextField
+                  select
+                  label="Tipo"
+                  value={selectedType}
+                  onChange={(e) => setSelectedType(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                >
+                  <MenuItem value="IP" sx={menuItemStyles}>
+                    IP
+                  </MenuItem>
+                  <MenuItem value="Interlocutor" sx={menuItemStyles}>
+                    Interlocutor
+                  </MenuItem>
+                  <MenuItem value="Todos" sx={menuItemStyles}>
+                    Todos
+                  </MenuItem>
+                </TextField>
+
+                <TextField
+                  select
+                  label="Turno"
+                  value={selectedShift}
+                  onChange={(e) => setSelectedShift(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                >
+                  {["Todos", "Manhã", "Tarde", "Noite"].map((value) => (
+                    <MenuItem key={value} value={value} sx={menuItemStyles}>
+                      {value}
+                    </MenuItem>
+                  ))}
+                </TextField>
+
+                <TextField
+                  id="date-initial"
+                  InputLabelProps={{ shrink: true }}
+                  label="Data Inicial"
+                  type="date"
+                  value={dateInitial}
+                  onChange={(e) => setDateInitial(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+
+                <TextField
+                  id="date-final"
+                  InputLabelProps={{ shrink: true }}
+                  label="Data Final"
+                  type="date"
+                  value={dateFinal}
+                  onChange={(e) => setDateFinal(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+
+                <TextField
+                  id="time-initial"
+                  InputLabelProps={{ shrink: true }}
+                  label="Horário Inicial"
+                  type="time"
+                  value={timeInitial}
+                  onChange={(e) => setTimeInitial(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+
+                <TextField
+                  id="time-final"
+                  InputLabelProps={{ shrink: true }}
+                  label="Horário Final"
+                  type="time"
+                  value={timeFinal}
+                  onChange={(e) => setTimeFinal(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+              </Box>
+            </Box>
+
+            {/* Legenda dos Turnos */}
+            <Box
+              display="flex"
+              gap="1.5rem"
+              alignItems="center"
+              mt="0.5rem"
+              mb="1rem"
+              sx={{
+                transition: "all 0.3s ease-in-out",
+              }}
+            >
+              <Typography
+                variant="subtitle2"
+                fontFamily="Inter, sans-serif"
+                fontWeight={600}
+                fontSize="0.95rem"
+                color="text.primary"
+              >
+                Legenda de Turnos:
+              </Typography>
+              <Box display="flex" gap="1rem" flexWrap="wrap">
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#000A2F"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Madrugada (00h-6h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#808CBF"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Manhã (6h-12h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#31438C"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Tarde (12h-18h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#0F1E55"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Noite (18h-00h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#D62727"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Alvos
+                  </Typography>
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        </Collapse>
+        <IconButton 
+          onClick={toggleExpanded} 
+          size="small" 
+          disableRipple
           sx={{
-            width: "100%",
-            minWidth: "0",
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.25rem",
+            transition: "all 0.3s ease-in-out",
+            "&:hover": {
+              transform: "scale(1.1)",
+            },
           }}
         >
-          <Typography
-            fontFamily={"Inter, sans-serif"}
-            fontWeight={600}
-            fontSize={"1.1rem"}
-            mb={0.5}
-            mt={0.5}
-          >
-            Seleção de IPs
-          </Typography>
-          <MultiSelect
-            style="gray"
-            placeholder="Selecione os IPs"
-            height="40px"
-            options={options}
-            selectedOptions={selectedOptions}
-            onChange={setSelectedOptions}
-          />
-        </Box>
-
-        <Box
-          width="100%"
-          display="flex"
-          py="0.2rem"
-          flexDirection="column"
-          gap="0.25rem"
-        >
-          <Typography
-            variant="caption"
-            fontSize={"14px"}
-            fontFamily="Inter, sans-serif"
-            fontWeight={600}
-            mb={0.5}
-          >
-            Filtrar por:
-          </Typography>
-          <Box
-            display="flex"
-            flexDirection="row"
-            flexWrap="wrap"
-            gap="1rem"
-            alignItems="center"
-          >
-            <TextField
-              select
-              label="Grupo"
-              value={selectedGroup}
-              onChange={(e) => setSelectedGroup(e.target.value)}
-              sx={{
-                ...focusedTextFieldStyles,
-                minWidth: "8rem",
-                backgroundColor: "transparent",
-              }}
-              size="small"
-            >
-              {["IP", "Interlocutor", "Ambos"].map((value) => (
-                <MenuItem key={value} value={value} sx={menuItemStyles}>
-                  {value}
-                </MenuItem>
-              ))}
-            </TextField>
-
-            <TextField
-              select
-              label="Tipo"
-              value={selectedType}
-              onChange={(e) => setSelectedType(e.target.value)}
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
-              size="small"
-            >
-              <MenuItem value="IP" sx={menuItemStyles}>
-                IP
-              </MenuItem>
-              <MenuItem value="Interlocutor" sx={menuItemStyles}>
-                Interlocutor
-              </MenuItem>
-              <MenuItem value="Todos" sx={menuItemStyles}>
-                Todos
-              </MenuItem>
-            </TextField>
-
-            <TextField
-              select
-              label="Simetria"
-              value={selectedSimmetry}
-              onChange={(e) => setSelectedSimmetry(e.target.value)}
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
-              size="small"
-            >
-              {["Simétricos", "Assimétricos", "Ambos"].map((value) => (
-                <MenuItem key={value} value={value} sx={menuItemStyles}>
-                  {value}
-                </MenuItem>
-              ))}
-            </TextField>
-
-            <TextField
-              id="date-initial"
-              InputLabelProps={{ shrink: true }}
-              label="Data Inicial"
-              type="date"
-              value={dateInitial}
-              onChange={(e) => setDateInitial(e.target.value)}
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
-              size="small"
-            />
-
-            <TextField
-              id="date-final"
-              InputLabelProps={{ shrink: true }}
-              label="Data Final"
-              type="date"
-              value={dateFinal}
-              onChange={(e) => setDateFinal(e.target.value)}
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
-              size="small"
-            />
-          </Box>
-        </Box>
-
-        {/* Legenda dos Turnos */}
-        <Box
-          display="flex"
-          gap="1.5rem"
-          alignItems="center"
-          mt="0.2rem"
-          mb="0.2rem"
-        >
-          <Typography
-            variant="subtitle2"
-            fontFamily="Inter, sans-serif"
-            fontWeight={600}
-            fontSize="0.95rem"
-          >
-            Legenda de Turnos:
-          </Typography>
-          <Box display="flex" gap="0.7rem">
-            <Box display="flex" alignItems="center" gap="0.3rem">
-              <Box
-                width="14px"
-                height="14px"
-                bgcolor="#808CBF"
-                borderRadius="50%"
-              />
-              <Typography variant="body2" fontSize="0.95rem">
-                Manhã
-              </Typography>
-            </Box>
-            <Box display="flex" alignItems="center" gap="0.3rem">
-              <Box
-                width="14px"
-                height="14px"
-                bgcolor="#31438C"
-                borderRadius="50%"
-              />
-              <Typography variant="body2" fontSize="0.95rem">
-                Tarde
-              </Typography>
-            </Box>
-            <Box display="flex" alignItems="center" gap="0.3rem">
-              <Box
-                width="14px"
-                height="14px"
-                bgcolor="#08102F"
-                borderRadius="50%"
-              />
-              <Typography variant="body2" fontSize="0.95rem">
-                Noite
-              </Typography>
-            </Box>
-            <Box display="flex" alignItems="center" gap="0.3rem">
-              <Box
-                width="14px"
-                height="14px"
-                bgcolor="#D62727"
-                borderRadius="50%"
-              />
-              <Typography variant="body2" fontSize="0.95rem">
-                Alvos
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
       </Box>
 
       <Box

--- a/src/routes/Web/index.tsx
+++ b/src/routes/Web/index.tsx
@@ -1,10 +1,13 @@
-import { Box, MenuItem, TextField, Typography } from "@mui/material";
+import { Box, MenuItem, TextField, Typography, Collapse, IconButton } from "@mui/material";
 import React, { useState, useMemo, useContext, useEffect } from "react";
 import WebChart from "../../components/dashboard/WebChart/WebChart";
 import MultiSelect from "../../components/multiSelect";
 import { AppContext } from "../../context/AppContext";
 import { createWeb } from "../../controllers/webController";
 import { WebLink, WebNode } from "../../interface/web/webInterface";
+import dayjs from "dayjs";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 
 const menuItemStyles = {
   padding: "4px 16px",
@@ -38,7 +41,6 @@ const focusedTextFieldStyles = {
     borderColor: "customButton.lightGray",
     borderWidth: "1px",
   },
-
   "& .MuiOutlinedInput-root": {
     "&:hover fieldset": {
       borderColor: "customButton.lightGray",
@@ -49,17 +51,33 @@ const focusedTextFieldStyles = {
     "& input": {
       outline: "none",
     },
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: "rgba(0, 0, 0, 0.23)",
+    },
   },
 };
 
 const WebRoute: React.FC = () => {
   const { operations, suspects, numbers, webChartFilters, setWebChartFilters } =
     useContext(AppContext);
-  const [dateInitial, setDateInitial] = useState("");
+  
+  const [expanded, setExpanded] = useState(true);
+  
+  // Definir data inicial como 1 mês atrás
+  const oneMonthAgo = new Date();
+  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+  const [dateInitial, setDateInitial] = useState(oneMonthAgo.toISOString().split('T')[0]);
   const [dateFinal, setDateFinal] = useState("");
+  const [timeInitial, setTimeInitial] = useState("00:00");
+  const [timeFinal, setTimeFinal] = useState("23:59");
+  const [selectedShift, setSelectedShift] = useState("Todos");
 
   const [nodes, setNodes] = useState<WebNode[]>([]);
   const [links, setLinks] = useState<WebLink[]>([]);
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
 
   async function handleWebChart() {
     await createWeb({
@@ -75,8 +93,34 @@ const WebRoute: React.FC = () => {
         if (!targetExists) {
           newNodes.push({
             id: link.target,
-            group: 6,
+            group: 6, // Grupo para interceptações
           });
+        }
+      });
+
+      // Padronizar grupos dos nós por turno
+      newNodes.forEach((node) => {
+        // Alvos
+        if (node.id.toLowerCase().includes("alvo")) {
+          node.group = 4;
+        } else if (node.id.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
+          // IPs: classificar pelo turno predominante dos links
+          const relatedLinks = response.links.filter(l => l.source === node.id || l.target === node.id);
+          const hourCounts = [0, 0, 0, 0, 0]; // [manhã, tarde, noite, alvo, madrugada]
+          relatedLinks.forEach(link => {
+            if (link.date) {
+              const hour = new Date(link.date).getHours();
+              if (hour >= 0 && hour < 6) hourCounts[4]++; // Madrugada
+              else if (hour >= 6 && hour < 12) hourCounts[0]++; // Manhã
+              else if (hour >= 12 && hour < 18) hourCounts[1]++; // Tarde
+              else hourCounts[2]++; // Noite
+            }
+          });
+          // Descobrir o turno predominante
+          const maxIdx = hourCounts.indexOf(Math.max(...hourCounts));
+          node.group = [1,2,3,4,5][maxIdx];
+          // Se não houver links com data, default manhã
+          if (hourCounts.every(c => c === 0)) node.group = 1;
         }
       });
 
@@ -90,35 +134,24 @@ const WebRoute: React.FC = () => {
   }, []);
 
   // Filtragem dos nós e links
-  // TODO: Remover mockData, usar nodes e links do handleWebChart, adicionar datas
-  const mockData = {
-    nodes: [{ id: "Alvo 1", group: 3 }],
-    links: [
-      { source: "Alvo 1", target: "Marinho", value: 342, date: "2024-06-01" },
-    ],
-  };
-  const options = mockData.nodes
-    .filter((x) => x.group === 3)
-    .map((node) => node.id);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const filteredData = useMemo(() => {
-    let filteredLinks = mockData.links;
+    let filteredLinks = links;
 
     // Filtro por datas
-    // if (dateInitial || dateFinal) {
-    //   filteredLinks = filteredLinks.filter((link) => {
-    //     const linkDate = dayjs(link.date);
-    //     const afterInitial = dateInitial
-    //       ? linkDate.isAfter(dayjs(dateInitial)) ||
-    //         linkDate.isSame(dayjs(dateInitial))
-    //       : true;
-    //     const beforeFinal = dateFinal
-    //       ? linkDate.isBefore(dayjs(dateFinal)) ||
-    //         linkDate.isSame(dayjs(dateFinal))
-    //       : true;
-    //     return afterInitial && beforeFinal;
-    //   });
-    // }
+    if (dateInitial || dateFinal) {
+      filteredLinks = filteredLinks.filter((link) => {
+        const linkDate = dayjs(link.date);
+        const afterInitial = dateInitial
+          ? linkDate.isAfter(dayjs(dateInitial)) ||
+            linkDate.isSame(dayjs(dateInitial))
+          : true;
+        const beforeFinal = dateFinal
+          ? linkDate.isBefore(dayjs(dateFinal)) ||
+            linkDate.isSame(dayjs(dateFinal))
+          : true;
+        return afterInitial && beforeFinal;
+      });
+    }
 
     // Filtro por alvos selecionados
     if (webChartFilters.options.length > 0) {
@@ -130,27 +163,36 @@ const WebRoute: React.FC = () => {
     }
 
     // Filtro por Grupo
-    if (webChartFilters.group !== "Ambos") {
+    if (webChartFilters.group !== "Todos") {
       if (webChartFilters.group === "Grupo") {
         filteredLinks = filteredLinks.filter((link) => {
-          const sourceNode = mockData.nodes.find((n) => n.id === link.source);
-          const targetNode = mockData.nodes.find((n) => n.id === link.target);
+          const sourceNode = nodes.find((n) => n.id === link.source);
+          const targetNode = nodes.find((n) => n.id === link.target);
           return sourceNode?.group === 4 || targetNode?.group === 4;
         });
       } else if (webChartFilters.group === "Número") {
         filteredLinks = filteredLinks.filter((link) => {
-          const sourceNode = mockData.nodes.find((n) => n.id === link.source);
-          const targetNode = mockData.nodes.find((n) => n.id === link.target);
+          const sourceNode = nodes.find((n) => n.id === link.source);
+          const targetNode = nodes.find((n) => n.id === link.target);
           return sourceNode?.group !== 4 && targetNode?.group !== 4;
         });
       }
     }
 
-    // Filtro de Simetria
-    if (webChartFilters.symmetry !== "Ambos") {
+    // Filtro por Tipo
+    if (webChartFilters.type !== "Todos") {
       filteredLinks = filteredLinks.filter((link) => {
-        const sourceNode = mockData.nodes.find((n) => n.id === link.source);
-        const targetNode = mockData.nodes.find((n) => n.id === link.target);
+        // Aqui você deve implementar a lógica de filtro por tipo
+        // baseado nos dados reais que você recebe da API
+        return true; // Temporário até implementar a lógica real
+      });
+    }
+
+    // Filtro de Simetria
+    if (webChartFilters.symmetry !== "Todos") {
+      filteredLinks = filteredLinks.filter((link) => {
+        const sourceNode = nodes.find((n) => n.id === link.source);
+        const targetNode = nodes.find((n) => n.id === link.target);
         if (!sourceNode || !targetNode) return false;
         if (webChartFilters.symmetry === "Simétricos") {
           return sourceNode.group === targetNode.group;
@@ -161,15 +203,14 @@ const WebRoute: React.FC = () => {
       });
     }
 
-    // Filtro por Tipo (apenas exemplo, pois não há campo de tipo real)
-    // Aqui não há campo real, então não filtra nada
-
     // Agora, só exibe nós que participam de algum link visível
     const nodeIds = new Set(filteredLinks.flatMap((l) => [l.source, l.target]));
     const filteredNodes = nodes.filter((n) => nodeIds.has(n.id));
 
     return { nodes: filteredNodes, links: filteredLinks };
-  }, [webChartFilters, dateInitial, dateFinal]);
+  }, [webChartFilters, dateInitial, dateFinal, nodes, links]);
+
+  const options = nodes.map((node) => node.id);
 
   return (
     <Box
@@ -178,183 +219,291 @@ const WebRoute: React.FC = () => {
       height="100vh"
       display="flex"
       flexDirection="column"
-      padding="1rem 0 0 0"
+      padding="0"
     >
-      <Box display="flex" flexDirection="column" gap="1rem" px="1rem">
-        <Box
-          sx={{
-            width: "fit-content",
-            minWidth: "25rem",
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.5rem",
-          }}
-        >
-          <Typography
-            fontFamily={"Inter, sans-serif"}
-            fontWeight={600}
-            fontSize={"1.25rem"}
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+        borderBottom={expanded ? "1px solid #e0e0e0" : "none"}
+        sx={{
+          transition: "all 0.3s ease-in-out",
+        }}
+      >
+        <Collapse in={expanded} timeout="auto">
+          <Box 
+            display="flex" 
+            flexDirection="column" 
+            gap="1.5rem" 
+            px="1.5rem"
+            py="1rem"
+            sx={{
+              transition: "all 0.3s ease-in-out",
+            }}
           >
-            Seleção de Alvos
-          </Typography>
-          <MultiSelect
-            style="gray"
-            placeholder="Selecione os nomes"
-            height="53px"
-            options={options}
-            selectedOptions={webChartFilters.options}
-            onChange={(opts) =>
-              setWebChartFilters({ ...webChartFilters, options: opts })
-            }
-          />
-        </Box>
-
-        <Box width="100%" display="flex" flexDirection="column" gap="0.5rem">
-          <Typography
-            variant="caption"
-            fontSize={"14px"}
-            fontFamily="Inter, sans-serif"
-            fontWeight={600}
-          >
-            Filtrar por:
-          </Typography>
-
-          <Box display="flex" flexDirection="row" flexWrap="wrap" gap="2rem">
-            <TextField
-              select
-              label="Grupo"
-              value={webChartFilters.group}
-              onChange={(e) =>
-                setWebChartFilters({
-                  ...webChartFilters,
-                  group: e.target.value,
-                })
-              }
-              sx={{ ...focusedTextFieldStyles, backgroundColor: "transparent" }}
+            <Box
+              sx={{
+                width: "fit-content",
+                minWidth: "25rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.75rem",
+              }}
             >
-              {["Grupo", "Número", "Ambos"].map((value) => (
-                <MenuItem key={value} value={value} sx={menuItemStyles}>
-                  {value}
-                </MenuItem>
-              ))}
-            </TextField>
+              <Typography
+                fontFamily={"Inter, sans-serif"}
+                fontWeight={600}
+                fontSize={"1.25rem"}
+                color="text.primary"
+              >
+                Seleção de Alvos
+              </Typography>
+              <MultiSelect
+                style="gray"
+                placeholder="Selecione os nomes"
+                height="53px"
+                options={options}
+                selectedOptions={webChartFilters.options}
+                onChange={(opts) =>
+                  setWebChartFilters({ ...webChartFilters, options: opts })
+                }
+              />
+            </Box>
 
-            <TextField
-              select
-              label="Tipo"
-              value={webChartFilters.type}
-              onChange={(e) =>
-                setWebChartFilters({ ...webChartFilters, type: e.target.value })
-              }
-              sx={focusedTextFieldStyles}
-            >
-              <MenuItem value="Texto" sx={menuItemStyles}>
-                Texto
-              </MenuItem>
-              <MenuItem
-                value="Vídeo"
+            <Box width="100%" display="flex" flexDirection="column" gap="0.75rem">
+              <Typography
+                variant="caption"
+                fontSize={"14px"}
+                fontFamily="Inter, sans-serif"
+                fontWeight={600}
+                color="text.primary"
+              >
+                Filtrar por:
+              </Typography>
+
+              <Box 
+                display="flex" 
+                flexDirection="row" 
+                flexWrap="wrap" 
+                gap="2.5rem"
                 sx={{
-                  ...menuItemStyles,
+                  transition: "all 0.3s ease-in-out",
                 }}
               >
-                Vídeo
-              </MenuItem>
-              <MenuItem value="Todos" sx={menuItemStyles}>
-                Todos
-              </MenuItem>
-            </TextField>
+                <TextField
+                  select
+                  label="Grupo"
+                  value={webChartFilters.group}
+                  onChange={(e) =>
+                    setWebChartFilters({
+                      ...webChartFilters,
+                      group: e.target.value,
+                    })
+                  }
+                  sx={{ ...focusedTextFieldStyles, backgroundColor: "transparent" }}
+                >
+                  {["Todos", "Grupo", "Número"].map((value) => (
+                    <MenuItem key={value} value={value} sx={menuItemStyles}>
+                      {value}
+                    </MenuItem>
+                  ))}
+                </TextField>
 
-            <TextField
-              select
-              label="Simetria"
-              value={webChartFilters.symmetry}
-              onChange={(e) =>
-                setWebChartFilters({
-                  ...webChartFilters,
-                  symmetry: e.target.value,
-                })
-              }
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
+                <TextField
+                  select
+                  label="Tipo"
+                  value={webChartFilters.type}
+                  onChange={(e) =>
+                    setWebChartFilters({ ...webChartFilters, type: e.target.value })
+                  }
+                  sx={focusedTextFieldStyles}
+                >
+                  {["Todos", "Texto", "Vídeo", "Áudio"].map((value) => (
+                    <MenuItem key={value} value={value} sx={menuItemStyles}>
+                      {value}
+                    </MenuItem>
+                  ))}
+                </TextField>
+
+                <TextField
+                  select
+                  label="Turno"
+                  value={selectedShift}
+                  onChange={(e) => setSelectedShift(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                >
+                  {["Todos", "Manhã", "Tarde", "Noite"].map((value) => (
+                    <MenuItem key={value} value={value} sx={menuItemStyles}>
+                      {value}
+                    </MenuItem>
+                  ))}
+                </TextField>
+
+                <TextField
+                  id="date-initial"
+                  InputLabelProps={{ shrink: true }}
+                  label="Data Inicial"
+                  type="date"
+                  value={dateInitial}
+                  onChange={(e) => setDateInitial(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+
+                <TextField
+                  id="date-final"
+                  InputLabelProps={{ shrink: true }}
+                  label="Data Final"
+                  type="date"
+                  value={dateFinal}
+                  onChange={(e) => setDateFinal(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+
+                <TextField
+                  id="time-initial"
+                  InputLabelProps={{ shrink: true }}
+                  label="Horário Inicial"
+                  type="time"
+                  value={timeInitial}
+                  onChange={(e) => setTimeInitial(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+
+                <TextField
+                  id="time-final"
+                  InputLabelProps={{ shrink: true }}
+                  label="Horário Final"
+                  type="time"
+                  value={timeFinal}
+                  onChange={(e) => setTimeFinal(e.target.value)}
+                  sx={focusedTextFieldStyles}
+                />
+              </Box>
+            </Box>
+
+            {/* Legenda dos Turnos */}
+            <Box
+              display="flex"
+              gap="1.5rem"
+              alignItems="center"
+              mt="0.5rem"
+              mb="1rem"
+              sx={{
+                transition: "all 0.3s ease-in-out",
+              }}
             >
-              {["Simétricos", "Assimétricos", "Ambos"].map((value) => (
-                <MenuItem key={value} value={value} sx={menuItemStyles}>
-                  {value}
-                </MenuItem>
-              ))}
-            </TextField>
-
-            <TextField
-              id="date-initial"
-              InputLabelProps={{ shrink: true }}
-              label="Data Inicial"
-              type="date"
-              value={dateInitial}
-              onChange={(e) => setDateInitial(e.target.value)}
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
-            />
-
-            <TextField
-              id="date-final"
-              InputLabelProps={{ shrink: true }}
-              label="Data Final"
-              type="date"
-              value={dateFinal}
-              onChange={(e) => setDateFinal(e.target.value)}
-              sx={{ ...focusedTextFieldStyles, minWidth: "8rem" }}
-            />
+              <Typography
+                variant="subtitle2"
+                fontFamily="Inter, sans-serif"
+                fontWeight={600}
+                fontSize="0.95rem"
+                color="text.primary"
+              >
+                Legenda de Turnos:
+              </Typography>
+              <Box display="flex" gap="1rem" flexWrap="wrap">
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#000A2F"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Madrugada (00h-6h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#808CBF"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Manhã (6h-12h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#31438C"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Tarde (12h-18h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#0F1E55"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Noite (18h-00h)
+                  </Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap="0.5rem">
+                  <Box
+                    width="14px"
+                    height="14px"
+                    bgcolor="#D62727"
+                    borderRadius="50%"
+                    sx={{
+                      transition: "all 0.3s ease-in-out",
+                      "&:hover": {
+                        transform: "scale(1.1)",
+                      },
+                    }}
+                  />
+                  <Typography variant="body2" fontSize="0.95rem" color="text.primary">
+                    Alvos
+                  </Typography>
+                </Box>
+              </Box>
+            </Box>
           </Box>
-        </Box>
-
-        {/* Legenda dos Turnos */}
-        <Box
-          display="flex"
-          gap="1rem"
-          alignItems="center"
-          mt="0.2rem"
-          mb="0.8rem"
+        </Collapse>
+        <IconButton 
+          onClick={toggleExpanded} 
+          size="small" 
+          disableRipple
+          sx={{
+            transition: "all 0.3s ease-in-out",
+            "&:hover": {
+              transform: "scale(1.1)",
+            },
+          }}
         >
-          <Typography
-            variant="subtitle2"
-            fontFamily="Inter, sans-serif"
-            fontWeight={600}
-            fontSize="0.95rem"
-          >
-            Legenda de Turnos:
-          </Typography>
-          <Box display="flex" alignItems="center" gap="0.3rem">
-            <Box
-              width="14px"
-              height="14px"
-              bgcolor="#D62727"
-              borderRadius="50%"
-            />
-            <Typography variant="body2" fontSize="0.95rem">
-              Alvos
-            </Typography>
-          </Box>
-          <Box display="flex" alignItems="center" gap="0.3rem">
-            <Box
-              width="14px"
-              height="14px"
-              bgcolor="#FFA000"
-              borderRadius="50%"
-            />
-            <Typography variant="body2" fontSize="0.95rem">
-              Suspeitos
-            </Typography>
-          </Box>
-          <Box display="flex" alignItems="center" gap="0.3rem">
-            <Box
-              width="14px"
-              height="14px"
-              bgcolor="#757575"
-              borderRadius="50%"
-            />
-            <Typography variant="body2" fontSize="0.95rem">
-              Interceptações
-            </Typography>
-          </Box>
-        </Box>
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
       </Box>
 
       <Box
@@ -373,7 +522,7 @@ const WebRoute: React.FC = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <WebChart data={{ nodes: nodes, links: links }} />
+          <WebChart data={filteredData} />
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
Este PR traz uma série de ajustes e correções nos filtros aplicados aos gráficos de Teia e Dashboard, com foco em aprimorar a usabilidade e padronizar o comportamento dos elementos visuais.

**🔧 Alterações realizadas:**

Teia/TeiaIP e Dashboard
![padrã2](https://github.com/user-attachments/assets/8801d946-0563-4d30-a5ae-c816626167c5)
![padrão](https://github.com/user-attachments/assets/3f8eea10-898e-4947-bf1b-97216ba146dc)

- Remoção da simetria nos gráficos para facilitar a leitura das conexões reais.
- Adição de filtros de Horário e Turno para melhor segmentação dos dados.
**- Filtros gerais**
- Inclusão de filtro de Tipo com as opções: texto, vídeo e áudio.
- Todos os filtros agora iniciam com a opção padrão "Todos" para indicar ausência de filtro.
- Ajuste no estilo visual da seleção de IPs, agora padronizado com o componente usado no alvo da teia de mensagens.
**- Datas padrão**
- Data inicial: automaticamente definida como 1 mês atrás.
- Data final: deixada em aberto (não definida), conforme o esperado.
**- Outros ajustes**
- Melhorias visuais nos filtros.
- Correções gerais nos componentes de seleção dos gráficos (tanto da Teia quanto do Dashboard).